### PR TITLE
Remove NewBytes and fallback to NewCopyBytes behaviour

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -39,11 +39,7 @@ func (a *Arena) NewCopyBytes(b []byte) *Value {
 
 // NewBytes returns a bytes value.
 func (a *Arena) NewBytes(b []byte) *Value {
-	v := a.c.getValue()
-	v.t = TypeBytes
-	v.b = b
-	v.l = uint64(len(b))
-	return v
+	return a.NewCopyBytes(b)
 }
 
 // NewUint returns a new uint value.


### PR DESCRIPTION
This PR fallback `NewBytes` to `NewCopyBytes`. I keep both functions in order not to break API compatibility. It is not possible to use `NewBytes` without copying the input because of how the values get reused between different Arena allocations.